### PR TITLE
Add TCP client interface for WiFi SCPI communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Arduino library for controlling Red Pitaya boards via SCPI server.
 You can get acquainted with Red Pitaya products [here](https://redpitaya.com).
 Information about SCPI server is located [here](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/scpi.html).
 
+# Usage
+
+The library can communicate with a Red Pitaya over UART or over TCP using any
+Arduino `Client` implementation (Ethernet or Wi-Fi). Use `initStream()` for a
+serial `Stream` and `initClient()` with a network `Client` such as
+`WiFiClient`.
+
 # Dependencies
  * [Red pitaya boards](https://redpitaya.com/stemlab-125-14/).
 

--- a/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
+++ b/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
@@ -148,7 +148,7 @@ void setup() {
   // if you get a connection, report back via serial:
   if (client.connect(server, 5000)) {
     Serial.println("connected");
-    rp.initStream(&client);
+    rp.initClient(&client);
     acquire();
     client.stop();
   } else {

--- a/examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino
+++ b/examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino
@@ -59,7 +59,7 @@ void setup() {
   // if you get a connection, report back via serial:
   if (client.connect(server, 5000)) {
     Serial.println("connected");
-    rp.initStream(&client);
+    rp.initClient(&client);
     isInit = true;
   } else {
     // if you didn't get a connection to the server:

--- a/examples/wifi/WiFi_analog_io/WiFi_analog_io.ino
+++ b/examples/wifi/WiFi_analog_io/WiFi_analog_io.ino
@@ -1,0 +1,64 @@
+// Example showing how to use RP SCPI API over WiFi.
+// Connect Arduino R4 WiFi to a Red Pitaya board via TCP.
+
+#include <WiFiS3.h>
+
+#include "SCPI_RP.h"
+
+char ssid[] = "YOUR_SSID";           // your network SSID
+char pass[] = "YOUR_PASSWORD";       // your network password
+IPAddress server(192, 168, 1, 100);  // Red Pitaya IP
+
+WiFiClient client;
+
+scpi_rp::SCPIRedPitaya rp;
+
+bool isInit = false;
+float value = 0;
+
+void setup() {
+  Serial.begin(115200);
+
+  if (WiFi.status() == WL_NO_MODULE) {
+    Serial.println("Communication with WiFi module failed!");
+    while (true);
+  }
+
+  while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
+    Serial.println("Connecting to WiFi...");
+    delay(10000);
+  }
+
+  Serial.print("Connected. IP address: ");
+  Serial.println(WiFi.localIP());
+
+  if (client.connect(server, 5000)) {
+    Serial.println("Connected to Red Pitaya");
+    rp.initClient(&client);
+    isInit = true;
+  } else {
+    Serial.println("Connection failed");
+  }
+}
+
+void loop() {
+  if (isInit) {
+    float in_value = 0;
+    if ((value * 10) > 18) value = 0;
+    if (!rp.aio.state(scpi_rp::AOUT_0, value)) {
+      Serial.println("Error set value");
+    }
+    if (!rp.aio.stateQ(scpi_rp::AOUT_0, &in_value)) {
+      Serial.println("Error get value");
+    }
+    Serial.print("AOUT_0 value = ");
+    Serial.println(in_value);
+    if (!rp.aio.stateQ(scpi_rp::AIN_0, &in_value)) {
+      Serial.println("Error get value");
+    }
+    Serial.print("AIN_0 value = ");
+    Serial.println(in_value);
+    delay(1000);
+    value += 0.1;
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Device Control
 url=https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 architectures=*
 includes=SCPI_RP.h
-depends=Ethernet
+depends=Ethernet,WiFiS3

--- a/src/SCPI_RP.cpp
+++ b/src/SCPI_RP.cpp
@@ -12,6 +12,7 @@
 #include "SCPI_RP.h"
 
 #include "common/base_io.h"
+#include "network/tcp_scpi.h"
 #include "uart/uart_scpi.h"
 
 using namespace scpi_rp;
@@ -39,4 +40,23 @@ void SCPIRedPitaya::initStream(Stream *serial) {
   acq.trigger.setInterface(u);
   acq.dma.settings.setInterface(u);
   acq.dma.data.setInterface(u);
+}
+
+void SCPIRedPitaya::initClient(Client *client) {
+  TCPInterface *c = new TCPInterface();
+  c->init(client);
+  g_base_io = c;
+  system.setInterface(c);
+  dio.setInterface(c);
+  aio.setInterface(c);
+  daisy.setInterface(c);
+  pll.setInterface(c);
+  system_led.setInterface(c);
+  gen.setInterface(c);
+  acq.control.setInterface(c);
+  acq.settings.setInterface(c);
+  acq.data.setInterface(c);
+  acq.trigger.setInterface(c);
+  acq.dma.settings.setInterface(c);
+  acq.dma.data.setInterface(c);
 }

--- a/src/SCPI_RP.h
+++ b/src/SCPI_RP.h
@@ -12,6 +12,7 @@
 #ifndef SCPI_RP_H
 #define SCPI_RP_H
 
+#include <Client.h>
 #include <Stream.h>
 #include <stdint.h>
 
@@ -39,6 +40,7 @@ class SCPIRedPitaya {
    *  @param serial Stream for interface.
    */
   void initStream(Stream *serial);
+  void initClient(Client *client);
 
   SCPIAio aio;
   SCPIDaisy daisy;

--- a/src/network/tcp_scpi.cpp
+++ b/src/network/tcp_scpi.cpp
@@ -1,0 +1,37 @@
+#include "tcp_scpi.h"
+
+using namespace scpi_rp;
+
+TCPInterface::TCPInterface() : m_client(nullptr) {}
+
+TCPInterface::~TCPInterface() {}
+
+int TCPInterface::init(Client *client) {
+  m_client = client;
+  return 0;
+}
+
+scpi_size TCPInterface::write(const uint8_t *_data, scpi_size _size) {
+  scpi_size pos = 0;
+  scpi_size s = _size;
+  while (pos < _size) {
+    auto send = m_client->write(_data + pos, s);
+    pos += send;
+    s -= send;
+  }
+  return pos;
+}
+
+scpi_size TCPInterface::readToBuffer() {
+  if (!m_client) return 0;
+  scpi_size free_size = BASE_IO_BUFFER_SIZE - m_bufferSize;
+  if (free_size == 0) return 0;
+  scpi_size available = m_client->available();
+  if (available > free_size) available = free_size;
+  scpi_size rs = 0;
+  if (available > 0) {
+    rs = m_client->read(m_buffer + m_bufferSize, available);
+    m_bufferSize += rs;
+  }
+  return rs;
+}

--- a/src/network/tcp_scpi.h
+++ b/src/network/tcp_scpi.h
@@ -1,0 +1,29 @@
+#ifndef TCP_SCPI_H
+#define TCP_SCPI_H
+
+#include <Client.h>
+#include <stdint.h>
+
+#include "common/base_io.h"
+#include "common/structs.h"
+
+namespace scpi_rp {
+
+class TCPInterface : public BaseIO {
+ public:
+  TCPInterface();
+  ~TCPInterface();
+
+  int init(Client *client);
+
+  scpi_size write(const uint8_t *_data, scpi_size _size) override;
+
+ private:
+  scpi_size readToBuffer() override;
+
+  Client *m_client;
+};
+
+}  // namespace scpi_rp
+
+#endif


### PR DESCRIPTION
## Summary
- add generic TCPInterface to communicate over network clients
- expose `initClient()` for network initialization and update docs/examples
- add WiFi example and WiFiS3 dependency

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_689bdbbe0a5c83259e198ed694d88b12